### PR TITLE
Write `interrogate` action and add missing docstrings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
         run: |
           python -m pytest tests
 
+      - name: Check absolute documentation coverage
+        run: |
+          python -m pip install interrogate
+          python -m interrogate --ignore-init-method --fail-under=100 src
+
       - name: Check code format
         run: |
           python -m pip install black

--- a/src/synthgauge/__init__.py
+++ b/src/synthgauge/__init__.py
@@ -1,3 +1,5 @@
+""" A library for evaluating synthetic data. """
+
 # flake8: noqa
 import pkg_resources
 

--- a/src/synthgauge/datasets.py
+++ b/src/synthgauge/datasets.py
@@ -1,3 +1,5 @@
+""" Functions for creating toy datasets. """
+
 import random
 
 import numpy as np

--- a/src/synthgauge/evaluate.py
+++ b/src/synthgauge/evaluate.py
@@ -20,14 +20,14 @@ from .utils import df_combine, launder
 class Evaluator(object):
     """
     The central class in ``synthgauge`` used to hold and evaluate data via
-    metrics or visualisation.
+    metrics and visualisation.
 
     Parameters
     ----------
     real: pandas.DataFrame
-        The real, observed dataset to be evaluated against.
+        Dataframe containing the real data.
     synth: pandas.DataFrame
-        A synthesised version of the real data to be evaluated.
+        Dataframe containing the synthetic data.
     handle_nans: str
         Whether to drop missing values. If yes, use "drop" (default).
 

--- a/src/synthgauge/evaluate.py
+++ b/src/synthgauge/evaluate.py
@@ -1,3 +1,5 @@
+""" The ``Evaluator`` class. """
+
 import pickle
 import warnings
 from copy import deepcopy
@@ -16,7 +18,24 @@ from .utils import df_combine, launder
 
 
 class Evaluator(object):
-    """ """
+    """
+    The central class in ``synthgauge`` used to hold and evaluate data via
+    metrics or visualisation.
+
+    Parameters
+    ----------
+    real: pandas.DataFrame
+        The real, observed dataset to be evaluated against.
+    synth: pandas.DataFrame
+        A synthesised version of the real data to be evaluated.
+    handle_nans: str
+        Whether to drop missing values. If yes, use "drop" (default).
+
+    Returns
+    -------
+    synthgauge.Evaluator
+        An ``Evaluator`` object ready for metric and visual evaluation.
+    """
 
     def __init__(self, real, synth, handle_nans="drop"):
         """ """

--- a/src/synthgauge/metrics/__init__.py
+++ b/src/synthgauge/metrics/__init__.py
@@ -1,3 +1,5 @@
+""" A submodule for all utility and privacy metrics. """
+
 from .classification import classification_comparison
 from .cluster import multi_clustered_MSD
 from .correlation import correlation_MSD, correlation_ratio_MSE, cramers_v_MSE

--- a/src/synthgauge/metrics/classification.py
+++ b/src/synthgauge/metrics/classification.py
@@ -1,3 +1,5 @@
+""" Generic ``scikit-learn``-style classification utility metrics. """
+
 from collections import namedtuple
 
 from sklearn.compose import ColumnTransformer

--- a/src/synthgauge/metrics/cluster.py
+++ b/src/synthgauge/metrics/cluster.py
@@ -1,6 +1,5 @@
-"""
-clustering metric
-"""
+""" Utility metrics derived from centroid-based clustering. """
+
 import numpy as np
 from kmodes.kprototypes import KPrototypes
 from sklearn.cluster import KMeans
@@ -9,7 +8,7 @@ from ..utils import df_combine
 
 
 def clustered_MSD(combined, synthetic_indicator, method, k, random_state=None):
-    """clustered mean-squared difference
+    """Clustered mean-squared difference
 
     This metric performs a cluster analysis on the data and then considers the
     proportion of synthetic data in each cluster. It measures the difference

--- a/src/synthgauge/metrics/correlation.py
+++ b/src/synthgauge/metrics/correlation.py
@@ -1,3 +1,5 @@
+""" Correlation-based utility metrics. """
+
 import warnings
 from itertools import combinations, product
 

--- a/src/synthgauge/metrics/privacy.py
+++ b/src/synthgauge/metrics/privacy.py
@@ -1,4 +1,4 @@
-""" Privacy-based metrics (rather than utility). """
+""" Privacy metrics. """
 
 import numpy as np
 import pandas as pd

--- a/src/synthgauge/metrics/privacy.py
+++ b/src/synthgauge/metrics/privacy.py
@@ -1,3 +1,5 @@
+""" Privacy-based metrics (rather than utility). """
+
 import numpy as np
 import pandas as pd
 from sklearn.neighbors import LocalOutlierFactor, NearestNeighbors

--- a/src/synthgauge/metrics/propensity.py
+++ b/src/synthgauge/metrics/propensity.py
@@ -1,3 +1,5 @@
+""" Propensity-based utility metrics. """
+
 import random
 import warnings
 from collections import namedtuple

--- a/src/synthgauge/metrics/univariate_distance.py
+++ b/src/synthgauge/metrics/univariate_distance.py
@@ -1,3 +1,5 @@
+""" Univariate utility metrics. """
+
 import numpy as np
 import pandas as pd
 from scipy.spatial.distance import jensenshannon

--- a/src/synthgauge/plot.py
+++ b/src/synthgauge/plot.py
@@ -1,3 +1,5 @@
+""" Functions for visualising the utility of synthetic data. """
+
 from itertools import product
 
 import matplotlib as mpl
@@ -143,6 +145,7 @@ def plot_joint(
     # If a feature is categorical it must be used 'as_ordered' for plotting a
     # histogram
     def order(ft):
+        """Orders the given feature if it is categorical."""
         return ft.cat.as_ordered() if hasattr(ft, "cat") else ft
 
     sns.histplot(

--- a/src/synthgauge/plot.py
+++ b/src/synthgauge/plot.py
@@ -1,4 +1,4 @@
-""" Functions for visualising the utility of synthetic data. """
+""" Functions for visually evaluating synthetic data. """
 
 from itertools import product
 

--- a/src/synthgauge/utils.py
+++ b/src/synthgauge/utils.py
@@ -1,3 +1,5 @@
+""" Utility functions for handling real and synthetic data. """
+
 import pickle
 import warnings
 


### PR DESCRIPTION
To get `interrogate` up to 100%, we were missing a handful of docstrings. These were mainly module strings, but they are important for the API documentation.