### PR TITLE
Sort out pseudo-random number generation

### DIFF
--- a/src/synthgauge/metrics/propensity.py
+++ b/src/synthgauge/metrics/propensity.py
@@ -1,10 +1,10 @@
 """ Propensity-based utility metrics. """
 
-import math
 from collections import namedtuple
 
 import numpy as np
 import pandas as pd
+import scipy.special
 from sklearn.linear_model import LogisticRegression
 from sklearn.preprocessing import PolynomialFeatures
 from sklearn.tree import DecisionTreeClassifier
@@ -167,7 +167,7 @@ def _pmse_logr_statistics(combined, indicator):
     """
 
     num_rows, num_cols = combined.shape
-    num_predictors = num_cols + math.comb(num_cols, 2)
+    num_predictors = num_cols + scipy.special.binom(num_cols, 2)
     prop_synth = indicator.mean()
 
     loc = (num_predictors - 1) * (1 - prop_synth) ** 2 / num_rows

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,11 +9,11 @@ import synthgauge as sg
 def real():
     """Make some real (noiseless) data."""
 
-    return sg.datasets.make_blood_types_df(0, 0)
+    return sg.datasets.make_blood_types_df(0, 0, 0)
 
 
 @pytest.fixture
 def synth():
     """Make some synthetic (noisy) data."""
 
-    return sg.datasets.make_blood_types_df(1, 0)
+    return sg.datasets.make_blood_types_df(1, 0, 0)

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -313,7 +313,10 @@ def test_evaluate_custom_metric(evaluator, func):
 @settings(
     deadline=None,
     max_examples=15,
-    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    suppress_health_check=[
+        HealthCheck.function_scoped_fixture,
+        HealthCheck.data_too_large,
+    ],
 )
 def test_plot_histograms(real, synth, size):
     """Check that the histograms method produces a figure. Full tests

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -253,13 +253,7 @@ def test_plot_crosstab(real, synth, params):
         assert isinstance(ax, plt.Subplot)
         assert ax.get_xlabel() == x
         assert ax.get_ylabel() == y
-
-        total_count = sum(ax.collections[0]._A)
-        binning_error = sum(
-            pd.api.types.is_numeric_dtype(data[col]) for col in (x, y)
-        )
-        nrows = len(data)
-        assert total_count in range(nrows - binning_error, nrows + 1)
+        assert sum(ax.collections[0]._A) <= len(data)
 
 
 @given(


### PR DESCRIPTION
Previously, the package used global random number seeds, which is not best practice for reproducibility. In fact, `numpy` now explicitly requests users not do this.

Also, the propensity metrics included some "stochastic" elements that meant most results from these metrics could never be reproduced.

This PR does some refactoring for both of these issues, and updates the tests accordingly.