### PR TITLE
Resolve `feats` parameter

### DIFF
--- a/src/synthgauge/datasets.py
+++ b/src/synthgauge/datasets.py
@@ -5,15 +5,15 @@ import pandas as pd
 from sklearn.datasets import make_classification
 
 
-def _adjust_data_elements(X, y, noise, nan_prop, seed):
+def _adjust_data_elements(data, labels, noise, nan_prop, seed):
     """Adjust the given data and put it into a dataframe.
     This function is not intended to be used directly by users.
 
     Parameters
     ----------
-    X : numpy.ndarray
+    data : numpy.ndarray
         The data array to be adjusted.
-    y : numpy.ndarray
+    labels : numpy.ndarray
         A set of labels for classifying the rows of `data`.
     noise : float
         The amount of noise to inject into the data. Specifically,
@@ -27,13 +27,13 @@ def _adjust_data_elements(X, y, noise, nan_prop, seed):
 
     Returns
     -------
-    data : pandas.DataFrame
+    pandas.DataFrame
         The adjusted, combined dataframe.
     """
 
     rng = np.random.default_rng(seed)
 
-    data = np.column_stack((X, y))
+    data = np.column_stack((data, labels))
 
     num_cols = data.shape[1]
     num_nans = int(data.size * nan_prop)

--- a/src/synthgauge/evaluate.py
+++ b/src/synthgauge/evaluate.py
@@ -43,12 +43,12 @@ class Evaluator:
         if len(ignore_feats) > 0:
             msg = (
                 f"Features {', '.join(ignore_feats)} are not common to "
-                "`real` and `synth` and will be ignored in further analysis"
+                "`real` and `synth` and will be ignored in further analysis."
             )
 
             warnings.warn(msg)
 
-        self.feature_names = common_feats
+        self.feature_names = list(common_feats)
 
         # Metrics is private to apply some validation
         self.__metrics = dict()  # assign metrics and kwargs

--- a/src/synthgauge/metrics/cluster.py
+++ b/src/synthgauge/metrics/cluster.py
@@ -156,9 +156,9 @@ def multi_clustered_MSD(
     ----------
     real, synth : pandas.DataFrame
         Dataframes containing the real and synthetic data.
-    feats : str or list of str or None, default None
-        Feature(s) to use in the clustering. If `None` (default), all
-        features in `real` and `synth` are used.
+    feats : list of str or None, default None
+        Features to use in the clustering. If `None` (default), all
+        common features are used.
     method : {"kmeans", "kprototypes"}, default "kmeans"
         Clustering method to use. Only k-means and k-prototypes
         are implemented. If using k-means (default), only numeric

--- a/src/synthgauge/metrics/privacy.py
+++ b/src/synthgauge/metrics/privacy.py
@@ -1,7 +1,6 @@
 """Privacy metrics."""
 
 import numpy as np
-import pandas as pd
 from sklearn.neighbors import LocalOutlierFactor, NearestNeighbors
 
 from ..utils import cat_encode, df_combine, df_separate
@@ -162,10 +161,9 @@ def min_NN_dist(
     ----------
     real, synth : pandas.DataFrame
         Dataframes containing the real and synthetic data.
-    feats : str or list of str or None, default None
-        Feature(s) in `real` and `synth` to use when calculating
-        distance. If `None` (default), all features in both datasets are
-        used.
+    feats : list of str or None, default None
+        Features in `real` and `synth` to use when calculating
+        distance. If `None` (default), all common features are used.
     real_outliers_only : bool, default True
         Boolean indicating whether to filter out the real data inliers
         (default) or not.
@@ -233,9 +231,9 @@ def sample_overlap_score(
     ----------
     real, synth : pandas.DataFrame
         DataFrames containing the real and synthetic data.
-    feats : str or list of str or None, default None
+    feats : list of str or None, default None
         The features used to match records. If `None` (default), all
-        features in `real` are used.
+        common features are used.
     sample_size : float or int, default 0.2
         The ratio (if `sample_size` between 0 and 1) or count
         (`sample_size` > 1) of records to sample. Default is 0.2 (20%).
@@ -256,12 +254,7 @@ def sample_overlap_score(
         Estimated overlap score between `real` and `synth`.
     """
 
-    if isinstance(feats, (list, pd.Index)):
-        feats = feats
-    elif isinstance(feats, str):
-        feats = [feats]
-    else:
-        feats = real.columns.to_list()
+    feats = feats or real.columns.intersection(synth.columns).to_list()
 
     min_num_rows = min(real.shape[0], synth.shape[0])
     if 0 <= sample_size <= 1:

--- a/src/synthgauge/metrics/propensity.py
+++ b/src/synthgauge/metrics/propensity.py
@@ -402,7 +402,7 @@ def propensity_metrics(
         logistic regression with first-order interactions (`"logr"`).
     feats : list of str or None, default None
         List of features in the dataset to be used in the propensity
-        model. If `None` (default), all features are used.
+        model. If `None` (default), all common features are used.
     num_perms : int, default 20
         Number of permutations to consider when estimating the null case
         statistics with a CART model.
@@ -451,7 +451,7 @@ def propensity_metrics(
             f"Propensity method must be 'cart' or 'logr' not {method}."
         )
 
-    feats = feats or list(set(real.columns).intersection(synth.columns))
+    feats = feats or real.columns.intersection(synth.columns)
     combined, indicator = _combine_encode_and_pop(real[feats], synth[feats])
 
     if method == "logr":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,11 @@
 """Fixtures used by several tests."""
 
 import pytest
+from hypothesis import settings
 
 import synthgauge as sg
+
+settings.register_profile("ci", deadline=60000)
 
 
 @pytest.fixture

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -28,7 +28,7 @@ def test_init(datasets):
 
     assert evaluator.real_data.equals(real)
     assert evaluator.synth_data.equals(synth)
-    assert evaluator.feature_names.equals(columns)
+    assert evaluator.feature_names == list(columns)
     assert evaluator.metrics == {}
     assert evaluator.metric_results == {}
     assert list(evaluator.combined_data.columns) == list(columns) + ["source"]
@@ -45,7 +45,7 @@ def test_init_uncommon_features(datasets):
     with pytest.warns(UserWarning, match="^Features xyz are not"):
         evaluator = sg.Evaluator(real, synth)
 
-    assert evaluator.feature_names.equals(synth.columns)
+    assert evaluator.feature_names == list(synth.columns)
 
 
 @given(datasets(), st.one_of(st.just("drop"), st.text()))
@@ -377,7 +377,9 @@ def test_plot_correlation(real, synth, method):
 
 @given(joint_params())
 @settings(
-    deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture]
+    deadline=None,
+    max_examples=15,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
 )
 def test_plot_crosstab(real, synth, params):
     """Check that the crosstab method produces a figure. Full tests of

--- a/tests/test_metrics_correlation.py
+++ b/tests/test_metrics_correlation.py
@@ -12,7 +12,7 @@ from .utils import datasets, resolve_features
 
 @given(
     datasets(min_columns=2, available_dtypes=("float",), allow_nan=False),
-    st.one_of(st.none(), st.sampled_from(("a", ["a", "b"]))),
+    st.sampled_from((None, ["a", "b"])),
 )
 def test_correlation_MSD(datasets, feats):
     """Check that the mean-squared difference in Pearson's correlation
@@ -52,7 +52,7 @@ def test_cramers_v(datasets):
 
 @given(
     datasets(2, 2, available_dtypes=("object", "bool")),
-    st.one_of(st.none(), st.sampled_from(("a", ["a", "b"]))),
+    st.sampled_from((None, ["a", "b"])),
 )
 def test_cramers_v_MSD(datasets, feats):
     """Check that the Cramer's V MSD can be calculated correctly."""
@@ -118,8 +118,8 @@ def test_correlation_ratio(datasets):
         max_value=1000,
         allow_nan=False,
     ),
-    st.one_of(st.none(), st.just(["a"])),
-    st.one_of(st.none(), st.just(["b"])),
+    st.sampled_from((None, ["a"])),
+    st.sampled_from((None, ["b"])),
 )
 def test_correlation_ratio_MSE(datasets, categorical, numeric):
     """Check that the categorical-continuous association mean-squared

--- a/tests/test_metrics_privacy.py
+++ b/tests/test_metrics_privacy.py
@@ -126,18 +126,19 @@ def test_min_NN_dist(datasets, outliers_only):
 
 @given(
     datasets(column_spec={"a": "object", "b": "object"}),
-    st.one_of(st.none(), st.sampled_from(("a", ["a", "b"]))),
+    st.sampled_from((None, ["a", "b"])),
     st.one_of(st.floats(0, 1, allow_nan=False), st.integers(10, 100)),
+    st.integers(0, 100),
     st.sampled_from(("unique", "sample")),
 )
-def test_sample_overlap_score(datasets, feats, size, score):
+def test_sample_overlap_score(datasets, feats, size, seed, score):
     """Check that sample overlap scores can be obtained."""
 
     real, synth = datasets
     assume(not (real.empty or synth.empty))
 
     score = privacy.sample_overlap_score(
-        real, synth, feats, sample_size=size, score_type=score
+        real, synth, feats, sample_size=size, seed=seed, score_type=score
     )
 
     assert isinstance(score, float)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -150,10 +150,11 @@ def test_plot_correlation_methods(real, method):
     else:
         columns = list(real.select_dtypes(include="number").columns)
 
-    for col, xlab, ylab in zip(
-        columns, ax.get_xticklabels(), ax.get_yticklabels()
-    ):
-        assert {col, xlab.get_text(), ylab.get_text()} == {col}
+    xticklabels = [lab.get_text() for lab in ax.get_xticklabels()]
+    yticklabels = [lab.get_text() for lab in ax.get_yticklabels()]
+
+    assert set(columns) == set(xticklabels)
+    assert set(columns) == set(yticklabels)
 
 
 @given(method=st.sampled_from(("pearson", "spearman", "cramers_v")))
@@ -170,7 +171,7 @@ def test_plot_correlation_method_errors(real, method):
         column, match = "blood_type", "^No numeric columns"
 
     with pytest.raises(ValueError, match=match):
-        _ = plot.plot_correlation(real, feats=column, method=method)
+        _ = plot.plot_correlation(real, feats=[column], method=method)
 
 
 @given(method=st.sampled_from(("pearson", "spearman", "cramers_v")))
@@ -193,10 +194,12 @@ def test_plot_correlation_two_datasets(real, synth, method):
 
     for i, ax in enumerate((rax, sax)):
         assert ax.get_title() == f"DataFrame {i + 1} Correlation"
-        for col, xlab, ylab in zip(
-            columns, ax.get_xticklabels(), ax.get_yticklabels()
-        ):
-            assert {col, xlab.get_text(), ylab.get_text()} == {col}
+
+        xticklabels = [lab.get_text() for lab in ax.get_xticklabels()]
+        yticklabels = [lab.get_text() for lab in ax.get_yticklabels()]
+
+        assert set(columns) == set(xticklabels)
+        assert set(columns) == set(yticklabels)
 
 
 @given(method=st.sampled_from(("pearson", "spearman", "cramers_v")))
@@ -229,10 +232,11 @@ def test_plot_correlation_difference(real, synth, method):
         else:
             assert ax.get_title() == f"DataFrame {i + 1} Correlation"
 
-        for col, xlab, ylab in zip(
-            columns, ax.get_xticklabels(), ax.get_yticklabels()
-        ):
-            assert {col, xlab.get_text(), ylab.get_text()} == {col}
+        xticklabels = [lab.get_text() for lab in ax.get_xticklabels()]
+        yticklabels = [lab.get_text() for lab in ax.get_yticklabels()]
+
+        assert set(columns) == set(xticklabels)
+        assert set(columns) == set(yticklabels)
 
 
 @given(params=joint_params())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,7 +11,7 @@ from synthgauge import utils
 from .utils import datasets, resolve_features
 
 
-@given(datasets(), st.one_of(st.none(), st.sampled_from(("a", ["a"]))))
+@given(datasets(), st.sampled_from((None, ["a"])))
 def test_df_combine(datasets, feats):
     """Check that two datasets can be combined when features are named
     individually, given as a list or not specified."""
@@ -28,11 +28,7 @@ def test_df_combine(datasets, feats):
     assert list(combined.columns) == columns + ["source"]
 
 
-@given(
-    datasets(),
-    st.one_of(st.none(), st.sampled_from(("a", ["a"]))),
-    st.booleans(),
-)
+@given(datasets(), st.sampled_from((None, ["a"])), st.booleans())
 def test_df_separate(datasets, feats, drop):
     """Check that a dataset can be separated into two parts."""
 
@@ -64,10 +60,7 @@ def test_df_separate(datasets, feats, drop):
         assert original.equals(separate)
 
 
-@given(
-    datasets(allow_nan=False),
-    st.one_of(st.none(), st.sampled_from(("a", ["a"]))),
-)
+@given(datasets(allow_nan=False), st.sampled_from((None, ["a"])))
 def test_launder(datasets, feats):
     """Check that two datasets can have their features 'laundered'."""
 
@@ -93,10 +86,7 @@ def test_launder(datasets, feats):
             ]
 
 
-@given(
-    datasets(available_dtypes=("object",)),
-    st.one_of(st.none(), st.sampled_from(("a", ["a"]))),
-)
+@given(datasets(available_dtypes=["object"]), st.sampled_from((None, ["a"])))
 def test_cat_encode_categorical(datasets, feats):
     """Check that a dataset with object-only columns can be categorised
     and integer-encoded."""
@@ -182,7 +172,7 @@ def test_cat_encode_mixed(datasets, force):
         assert data[col].to_list() == [categories[code] for code in out[col]]
 
 
-@given(datasets(available_dtypes=("object",)))
+@given(datasets(available_dtypes=["object"]))
 def test_cat_encode_convert_only(datasets):
     """Check that a dataset can be categorised without being encoded."""
 
@@ -191,11 +181,11 @@ def test_cat_encode_convert_only(datasets):
 
     out, cats = utils.cat_encode(data, convert_only=True)
 
-    columns = list(data.columns)
+    columns = data.columns
 
     assert cats is None
     assert isinstance(out, pd.DataFrame)
-    assert set(data.columns) == set(out.columns)
+    assert set(columns) == set(out.columns)
     assert all(np.array_equal(data[col], (out[col].values)) for col in columns)
 
     for col in columns:
@@ -204,7 +194,7 @@ def test_cat_encode_convert_only(datasets):
         assert set(out[col].cat.categories) == set(data[col].unique())
 
 
-@given(datasets(available_dtypes=("object",)), st.integers(1, 10))
+@given(datasets(available_dtypes=["object"]), st.integers(1, 10))
 @settings(deadline=None)
 def test_feature_density_diff(datasets, bins):
     """Check that histogram-based density differences can be computed

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -18,7 +18,6 @@ available_columns = (
 
 blood_type_feats = st.one_of(
     st.none(),
-    st.sampled_from(available_columns),
     st.lists(
         st.sampled_from(available_columns), min_size=1, max_size=4, unique=True
     ),
@@ -28,14 +27,7 @@ blood_type_feats = st.one_of(
 def resolve_features(feats, data):
     """Resolve the specified features so they are always a list."""
 
-    if isinstance(feats, str):
-        columns = list([feats])
-    elif isinstance(feats, list):
-        columns = list(feats)
-    else:
-        columns = list(data.columns)
-
-    return columns
+    return feats or data.columns.to_list()
 
 
 @st.composite

--- a/tox.ini
+++ b/tox.ini
@@ -16,4 +16,4 @@ commands =
     python -m isort --check src tests
     python -m flake8 src tests
     python -m interrogate src tests
-    python -m pytest tests
+    python -m pytest tests --hypothesis-profile=ci


### PR DESCRIPTION
There are several instances throughout the code base where a `feats` parameter is "resolved" to ensure it's a list.  This process looks something like:

```python
if isinstance(feats, str):
    feats = [feats]
if feats is None:
    feats = real.columns.to_list()
```

There are multiple, inconsistent versions of this block throughout, some of which are incorrectly implemented (see `synthgauge.plot.plot_correlation()` for example). As well as adding complexity to this resolution, passing single features to the functions using this would be exceptionally rare.

This PR unifies these resolution steps and removes the ability to pass a string for `feats`, simplifying the process to:

```python
feats = feats or real.columns.intersection(synth.columns)
```

With this change, you can still pass a single feature, you just have to do it like you would pass multiple features. Otherwise, the functionality remains much the same.