### PR TITLE
Remove redundant `if __name__...` blocks

### DIFF
--- a/src/synthgauge/datasets.py
+++ b/src/synthgauge/datasets.py
@@ -111,7 +111,3 @@ def make_blood_types_df(noise=0, proportion_nan=0, random_seed=None):
     ).cat.as_unordered()
 
     return df
-
-
-if __name__ == "__main__":
-    pass

--- a/src/synthgauge/evaluate.py
+++ b/src/synthgauge/evaluate.py
@@ -421,7 +421,3 @@ class Evaluator:
         return plot_qq(
             self.real_data, self.synth_data, feature, n_quantiles, figsize
         )
-
-
-if __name__ == "__main__":
-    pass

--- a/src/synthgauge/metrics/classification.py
+++ b/src/synthgauge/metrics/classification.py
@@ -205,7 +205,3 @@ def classification_comparison(
     )
 
     return ClassificationResult(*score_differences)
-
-
-if __name__ == "__main__":
-    pass

--- a/src/synthgauge/metrics/cluster.py
+++ b/src/synthgauge/metrics/cluster.py
@@ -192,7 +192,3 @@ def multi_clustered_MSD(
         )
 
     return min(cluster_MSDs)
-
-
-if __name__ == "__main__":
-    pass

--- a/src/synthgauge/metrics/correlation.py
+++ b/src/synthgauge/metrics/correlation.py
@@ -254,7 +254,3 @@ def correlation_ratio_MSE(
         )
 
     return _mean_squared_error(real_corr_ratio, synth_corr_ratio)
-
-
-if __name__ == "__main__":
-    pass

--- a/src/synthgauge/metrics/privacy.py
+++ b/src/synthgauge/metrics/privacy.py
@@ -300,7 +300,3 @@ def sample_overlap_score(
         scores.append(score)
 
     return np.mean(scores)
-
-
-if __name__ == "__main__":
-    pass

--- a/src/synthgauge/metrics/propensity.py
+++ b/src/synthgauge/metrics/propensity.py
@@ -471,7 +471,3 @@ def propensity_metrics(
     )
 
     return PropensityResult(observed, standard, ratio)
-
-
-if __name__ == "__main__":
-    pass

--- a/src/synthgauge/metrics/univariate_distance.py
+++ b/src/synthgauge/metrics/univariate_distance.py
@@ -625,7 +625,3 @@ def wilcoxon(real, synth, feature, **kwargs):
     """
 
     return stats.wilcoxon(real[feature], synth[feature], **kwargs)
-
-
-if __name__ == "__main__":
-    pass

--- a/src/synthgauge/plot.py
+++ b/src/synthgauge/plot.py
@@ -615,7 +615,3 @@ def plot_feat_density_diff(
     ax.set_title(title)
 
     return fig
-
-
-if __name__ == "__main__":
-    pass

--- a/src/synthgauge/utils.py
+++ b/src/synthgauge/utils.py
@@ -267,7 +267,3 @@ def feature_density_diff(real, synth, feature, bins=10):
     hist_diff = synth_hist - real_hist
 
     return hist_diff, bin_edges
-
-
-if __name__ == "__main__":
-    pass


### PR DESCRIPTION
No need to have these blocks are the ends of all the source files, as
far as I'm aware.