### PR TITLE
Sort packaging

### DIFF
--- a/docs_src/source/conf.py
+++ b/docs_src/source/conf.py
@@ -14,6 +14,7 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+import synthgauge as sg
 
 # -- Project information -----------------------------------------------------
 
@@ -22,7 +23,7 @@ copyright = '2022, Data Science Campus'
 author = 'Ali Cass & Tom White'
 
 # The full version, including alpha/beta/rc tags
-release = '1.0.0'
+release = sg.__version__
 napoleon_include_private_with_doc = False
 
 # -- General configuration ---------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ matplotlib>=3.3.2
 numpy>=1.19.2
 scikit-learn>=0.24.0
 pandas>=1.1.3
-pyqt5>=5.15
 scipy>=1.5.2
 seaborn==0.11.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = synthgauge
-version = 1.0.0
+version = attr:synthgauge.__version__
 author = Office For National Statistics Data Science Campus
 author_email = datacampus@ons.gov.uk
 description = A package for evaluating synthetic data
@@ -8,6 +8,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/datasciencecampus/synthgauge
 project_urls =
+    Documentation = https://datasciencecampus.github.io/synthgauge
     Bug Tracker = https://github.com/datasciencecampus/synthgauge/issues
 classifiers =
     Programming Language :: Python :: 3
@@ -25,7 +26,6 @@ install_requires =
     numpy>=1.19.2
     scikit-learn>=0.24.0
     pandas>=1.1.3
-    pyqt5>=5.15
     scipy>=1.5.2
     seaborn==0.11.0
 

--- a/src/synthgauge/__init__.py
+++ b/src/synthgauge/__init__.py
@@ -1,14 +1,8 @@
 """A library for evaluating synthetic data."""
 
-# flake8: noqa
-import pkg_resources
-
 from . import datasets, metrics, plot, utils
 from .evaluator import Evaluator
 
-try:
-    __version__ = pkg_resources.get_distribution("synthgauge").version
-except pkg_resources.DistributionNotFound:
-    # Raised when package has not been installed e.g. just
-    # src added to path.
-    __version__ = None
+__version__ = "1.0.0"
+
+__all__ = ["Evaluator", "datasets", "metrics", "plot", "utils", "__version__"]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,22 @@
+"""Simple test to check the version number."""
+
+import re
+
+import synthgauge as sg
+
+
+def test_version_regex():
+    """Check that the version number is in semantic versioning form.
+    Regex pattern lifted from https://semver.org.
+    """
+
+    pattern = (
+        "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)"
+        "(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+        "(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))"
+        "?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+    )
+    match = re.fullmatch(pattern, sg.__version__)
+
+    assert match is not None
+    assert match.group() == sg.__version__


### PR DESCRIPTION
Unfortunately, we can't use `poetry`, and we are limited by compatibility with Python 3.6 (for our internal use of `synthgauge`).

However, best practice is to single-source the package version. This PR does this by setting the attribute as a string in `src/synthgauge/__init__.py`. The other files (`setup.cfg` and `docs/source/conf.py`) can access this attribute directly at install and runtime.