### PR TITLE
Fix `seaborn@0.11.2` histogram bug

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     scikit-learn>=0.24.0
     pandas>=1.1.3
     scipy>=1.5.2
-    seaborn==0.11.0
+    seaborn>=0.11.0,<0.12.0
 
 [options.packages.find]
 where = src

--- a/src/synthgauge/evaluator.py
+++ b/src/synthgauge/evaluator.py
@@ -55,6 +55,7 @@ class Evaluator:
 
         self.real_data = real
         self.synth_data = synth
+        self.combined_data = utils.df_combine(self.real_data, self.synth_data)
 
     def describe_numeric(self):
         """Summarise numeric features.
@@ -236,12 +237,6 @@ class Evaluator:
         """Return __metrics."""
 
         return self.__metrics
-
-    @property
-    def combined_data(self):
-        """Return combined real and synthetic data."""
-
-        return utils.df_combine(self.real_data, self.synth_data)
 
     def drop_metric(self, metric):
         """Drops the named metric from the metrics dictionary.

--- a/src/synthgauge/utils.py
+++ b/src/synthgauge/utils.py
@@ -54,7 +54,7 @@ def df_combine(
     synth = synth[feats].copy()
     synth[source_col_name] = source_val_synth
 
-    combined = pd.concat([real, synth])
+    combined = pd.concat([real, synth], ignore_index=True)
 
     return combined
 


### PR DESCRIPTION
There was a small bug that came up when using `seaborn@0.11.2` where any duplicate values in the index meant `seaborn.histplot()` would throw an error (see https://github.com/mwaskom/seaborn/issues/2515 for details). So, our histogram plotting functions would, too, if we attempted to use the latest version in the `0.11` series. `0.11.2` was listed as a recommended release for all users, so fixing this is worthwhile.

This PR resolves the issue by ignoring the real and synthetic indices when we concatenate them. It also moves `Evaluator.combined_data` assignment to the `__init__` rather than having it as a property - although minor, this will improve the efficiency of some workflows.

Note that now the `seaborn@0.12` series has begun, there is scope for a future release where we move to their new, `ggplot`-style plotting syntax.