### PR TITLE
Bootstrapped pMSE null estimation

### DIFF
--- a/src/synthgauge/metrics/propensity.py
+++ b/src/synthgauge/metrics/propensity.py
@@ -372,7 +372,9 @@ def _pmse_cart_statistics(combined, indicator, num_perms, estimator, **kwargs):
     return loc, scale
 
 
-def pmse_ratio(combined, indicator, method, num_perms=None, **kwargs):
+def pmse_ratio(
+    combined, indicator, method, num_perms=None, estimator="perm", **kwargs
+):
     """The propensity score mean-squared error ratio.
 
     This is the ratio of observed pMSE to that expected under the null
@@ -394,6 +396,9 @@ def pmse_ratio(combined, indicator, method, num_perms=None, **kwargs):
     num_perms : int, optional
         Number of permutations to consider when estimating the null case
         statistics with a CART model.
+    estimator : {"perm", "boot"}
+        Which estimation process to use with a CART model. By default,
+        permutations are used to ensure back-compatibility.
     **kwargs : dict, optional
         Keyword arguments passed to the propensity model classifier.
 
@@ -426,13 +431,15 @@ def pmse_ratio(combined, indicator, method, num_perms=None, **kwargs):
         loc, _ = _pmse_logr_statistics(combined, indicator)
     if method == "cart":
         loc, _ = _pmse_cart_statistics(
-            combined, indicator, num_perms, **kwargs
+            combined, indicator, num_perms, estimator, **kwargs
         )
 
     return observed / loc
 
 
-def pmse_standardised(combined, indicator, method, num_perms=None, **kwargs):
+def pmse_standardised(
+    combined, indicator, method, num_perms=None, estimator="perm", **kwargs
+):
     """The standardised propensity score mean-squared error.
 
     This takes the observed pMSE and standardises it against the null
@@ -454,6 +461,9 @@ def pmse_standardised(combined, indicator, method, num_perms=None, **kwargs):
     num_perms : int, optional
         Number of permutations to consider when estimating the null case
         statistics with a CART model.
+    estimator : {"perm", "boot"}
+        Which estimation process to use with a CART model. By default,
+        permutations are used to ensure back-compatibility.
     **kwargs : dict, optional
         Keyword arguments passed to the propensity model.
 
@@ -486,14 +496,20 @@ def pmse_standardised(combined, indicator, method, num_perms=None, **kwargs):
         loc, scale = _pmse_logr_statistics(combined, indicator)
     if method == "cart":
         loc, scale = _pmse_cart_statistics(
-            combined, indicator, num_perms, **kwargs
+            combined, indicator, num_perms, estimator, **kwargs
         )
 
     return (observed - loc) / scale
 
 
 def propensity_metrics(
-    real, synth, method="cart", feats=None, num_perms=20, **kwargs
+    real,
+    synth,
+    method="cart",
+    feats=None,
+    num_perms=20,
+    estimator="perm",
+    **kwargs,
 ):
     """Propensity score-based metrics.
 
@@ -529,6 +545,9 @@ def propensity_metrics(
     num_perms : int, default 20
         Number of permutations to consider when estimating the null case
         statistics with a CART model.
+    estimator : {"perm", "boot"}
+        Which estimation process to use with a CART model. By default,
+        permutations are used to ensure back-compatibility.
     **kwargs : dict, optional
         Keyword arguments passed to the propensity model.
 
@@ -581,7 +600,7 @@ def propensity_metrics(
         loc, scale = _pmse_logr_statistics(combined, indicator)
     if method == "cart":
         loc, scale = _pmse_cart_statistics(
-            combined, indicator, num_perms, **kwargs
+            combined, indicator, num_perms, estimator, **kwargs
         )
 
     observed = pmse(combined, indicator, method, **kwargs)

--- a/src/synthgauge/metrics/propensity.py
+++ b/src/synthgauge/metrics/propensity.py
@@ -199,8 +199,43 @@ def _pmse_logr_statistics(combined, indicator):
 def _pmse_cart_stats_boot(real, num_perms, **kwargs):
     """Null statistic estimation for CART propensity via bootstrapping.
 
-    Estimate the location and scale of pMSE in the null case by repeated
-    bootstraps of the real data.
+    Estimate the location and scale of pMSE in the null case by taking
+    several bootstrapped samples of the real data, each being twice the
+    length of the original data. Half of the data are listed as real
+    while the other half are synthetic. These labelled data are then run
+    through the usual pMSE calculation procedure to produce a set.
+
+    The set of pMSE values are then summarised to give the estimated
+    mean and standard deviation.
+
+    Parameters
+    ----------
+    real : pandas.DataFrame
+        Dataframe containing the real data.
+    num_perms : int
+        Number of bootstraps to take. Named to be consistent with the
+        permutation-based method.
+    **kwargs : dict, optional
+        Keyword arguments passed to
+        `sklearn.tree.DecisionTreeClassifier`.
+
+    Returns
+    -------
+    loc : float
+        Estimated expectation of pMSE in the null case.
+    scale : float
+        Estimated standard deviation of pMSE in the null case.
+
+    Notes
+    -----
+    This estimation method removes any dependency on the synthetic data
+    being assessed, improving on the permutation-based method set out in
+    https://doi.org/10.1111/rssa.12358.
+
+    The details and justification for this method are present in
+    https://doi.org/10.29012/jpc.748. This implementation is adapted
+    from the source code submitted with the aforementioned paper:
+    https://github.com/ClaireMcKayBowen/Code-for-NIST-PSCR-Differential-Privacy-Synthetic-Data-Challenge
     """
 
     rng = np.random.default_rng(kwargs.get("random_state", None))

--- a/src/synthgauge/metrics/propensity.py
+++ b/src/synthgauge/metrics/propensity.py
@@ -353,7 +353,7 @@ def _pmse_cart_statistics(combined, indicator, num_perms, estimator, **kwargs):
     if estimator == "perm":
         message = (
             "The permutation method is flawed and will be removed in a future "
-            "release. See https://doi.org/10.29012/jpc.748 for details."
+            "release. Consider using `estimator='boot'` instead."
         )
         warnings.warn(message, FutureWarning)
 

--- a/src/synthgauge/metrics/propensity.py
+++ b/src/synthgauge/metrics/propensity.py
@@ -211,8 +211,8 @@ def _pmse_cart_stats_boot(combined, indicator, trials, **kwargs):
 
     Parameters
     ----------
-    real : pandas.DataFrame
-        Dataframe containing the real data.
+    combined : pandas.DataFrame
+        Dataframe containing the stacked real and synthetic data.
     trials : int
         Number of samples to take in the estimate.
     **kwargs : dict, optional

--- a/src/synthgauge/metrics/propensity.py
+++ b/src/synthgauge/metrics/propensity.py
@@ -1,5 +1,6 @@
 """Propensity-based utility metrics."""
 
+import warnings
 from collections import namedtuple
 
 import numpy as np
@@ -196,14 +197,14 @@ def _pmse_logr_statistics(combined, indicator):
     return loc, scale
 
 
-def _pmse_cart_stats_boot(real, num_perms, **kwargs):
+def _pmse_cart_stats_boot(combined, indicator, trials, **kwargs):
     """Null statistic estimation for CART propensity via bootstrapping.
 
     Estimate the location and scale of pMSE in the null case by taking
     several bootstrapped samples of the real data, each being twice the
     length of the original data. Half of the data are listed as real
     while the other half are synthetic. These labelled data are then run
-    through the usual pMSE calculation procedure to produce a set.
+    through the usual CART pMSE calculation procedure to produce a set.
 
     The set of pMSE values are then summarised to give the estimated
     mean and standard deviation.
@@ -212,9 +213,8 @@ def _pmse_cart_stats_boot(real, num_perms, **kwargs):
     ----------
     real : pandas.DataFrame
         Dataframe containing the real data.
-    num_perms : int
-        Number of bootstraps to take. Named to be consistent with the
-        permutation-based method.
+    trials : int
+        Number of samples to take in the estimate.
     **kwargs : dict, optional
         Keyword arguments passed to
         `sklearn.tree.DecisionTreeClassifier`.
@@ -232,32 +232,36 @@ def _pmse_cart_stats_boot(real, num_perms, **kwargs):
     being assessed, improving on the permutation-based method set out in
     https://doi.org/10.1111/rssa.12358.
 
-    The details and justification for this method are present in
+    A description of this method and its justification are presented in
     https://doi.org/10.29012/jpc.748. This implementation is adapted
     from the source code submitted with the aforementioned paper:
     https://github.com/ClaireMcKayBowen/Code-for-NIST-PSCR-Differential-Privacy-Synthetic-Data-Challenge
+
+    Note that the `random_state` keyword argument is used to
+    (independently) bootstrap samples and to fit the CART model. Without
+    specifying this, the results will not be reproducible.
     """
 
     rng = np.random.default_rng(kwargs.get("random_state", None))
-    real = pd.get_dummies(real, drop_first=True)
-    rows = len(real)
+    original = combined[indicator == 0]
+    rows = len(original)
 
     pmses = []
-    for perm in range(num_perms):
-        sampled = real.iloc[rng.integers(rows, size=2 * rows), :]
+    for perm in range(trials):
+        sampled = original.iloc[rng.integers(rows, size=2 * rows), :]
         indicator = np.repeat([0, 1], rows)
         pmses.append(pmse(sampled, indicator, method="cart", **kwargs))
 
     return np.mean(pmses), np.std(pmses)
 
 
-def _pmse_cart_statistics(combined, indicator, num_perms, **kwargs):
-    """Estimate the location and scale of pMSE in the null case by
-    repeating pMSE calculations on permuations of the indicator column
-    using a CART model.
+def _pmse_cart_stats_perm(combined, indicator, num_perms, **kwargs):
+    """Null statistic estimation for CART propensity via permutations.
 
-    The set of calculations are then summarised using the mean or
-    standard deviation, respectively.
+    Estimate the location and scale of pMSE in the null case by
+    repeating pMSE calculations on permuations of the indicator column
+    using a CART model. The set of calculations are then summarised
+    using the mean or standard deviation, respectively.
 
     Parameters
     ----------
@@ -282,15 +286,10 @@ def _pmse_cart_statistics(combined, indicator, num_perms, **kwargs):
     -----
     When using a CART propensity model, the number of predictors is
     unknown and the results used in `_pmse_logr_statistics` do not
-    apply.
-
-    To circumvent this, we repeatedly calculate pMSE using permutations
-    of the synthetic indicator column. This should approximate the
-    results for "properly" synthesised data without knowing :math:`k` a
-    priori.
-
-    Further details of this approach are available at:
-    https://doi.org/10.1111/rssa.12358
+    apply. To circumvent this, taking several permutations should
+    approximate the results for "properly" synthesised data without
+    knowing :math:`k` a priori. Further details of this approach are
+    available in https://doi.org/10.1111/rssa.12358.
 
     Note that the `random_state` keyword argument is used to
     (independently) create the permutations and to fit the CART model.
@@ -305,6 +304,72 @@ def _pmse_cart_statistics(combined, indicator, num_perms, **kwargs):
         pmses.append(pmse(combined, indicator, method="cart", **kwargs))
 
     return np.mean(pmses), np.std(pmses)
+
+
+def _pmse_cart_statistics(combined, indicator, num_perms, estimator, **kwargs):
+    """Null statistic estimation for CART-based propensity scores.
+
+    Estimation can either be carried out using permutations of the
+    combined indicator or via bootstrapping. The former is the original
+    method presented in https://doi.org/10.1111/rssa.12358, while the
+    latter (from https://doi.org/10.29012/jpc.748) improves on this by
+    removing dependence on the synthetic data.
+
+    Parameters
+    ----------
+    combined : pandas.DataFrame
+        Dataframe containing the real and synthetic data.
+    indicator : numpy.ndarray
+        Indicator for whether data are real (0) or synthetic (1).
+    num_perms : int
+        Number of trials to consider in the estimate.
+    estimator : {"perm", "boot"}
+        Which estimation process to use. By default, permutations are
+        used to ensure back-compatibility.
+    **kwargs : dict, optional
+        Keyword arguments to be passed to
+        `sklearn.tree.DecisionTreeClassifier`.
+
+    Returns
+    -------
+    loc : float
+        Estimated expectation of pMSE in the null case.
+    scale : float
+        Estimated standard deviation of pMSE in the null case.
+
+    Warns
+    -----
+    FutureWarning
+        The permutation method is flawed and will be removed in a
+        future minor version. See https://doi.org/10.29012/jpc.748 for
+        details.
+
+    Raises
+    ------
+    ValueError
+        If the estimation method, `estimator`, is not valid.
+    """
+
+    if estimator == "perm":
+        message = (
+            "The permutation method is flawed and will be removed in a future "
+            "release. See https://doi.org/10.29012/jpc.748 for details."
+        )
+        warnings.warn(message, FutureWarning)
+
+        loc, scale = _pmse_cart_stats_perm(
+            combined, indicator, num_perms, **kwargs
+        )
+
+    elif estimator == "boot":
+        loc, scale = _pmse_cart_stats_boot(
+            combined, indicator, num_perms, **kwargs
+        )
+
+    else:
+        raise ValueError("Estimation method must be `perm` or `boot`.")
+
+    return loc, scale
 
 
 def pmse_ratio(combined, indicator, method, num_perms=None, **kwargs):

--- a/tests/test_metrics_propensity.py
+++ b/tests/test_metrics_propensity.py
@@ -120,12 +120,15 @@ def test_pmse_logr_statistics(real, synth, seed):
 
 @given(st.integers(0, 100))
 @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
-def test_pmse_cart_stats_boot(real, seed):
+def test_pmse_cart_stats_boot(real, synth, seed):
     """Check that the bootstrap-based null statistics can be estimated
     correctly."""
 
+    synth = _reduce_synthetic(synth)
+    combined, indicator = propensity._combine_encode_and_pop(real, synth)
+
     loc, scale = propensity._pmse_cart_stats_boot(
-        real, num_perms=10, random_state=seed
+        combined, indicator, trials=10, random_state=seed
     )
 
     assert isinstance(loc, float)
@@ -139,7 +142,7 @@ def test_pmse_cart_stats_boot(real, seed):
 @settings(
     deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture]
 )
-def test_pmse_cart_statistics(real, synth, seed):
+def test_pmse_cart_stats_perm(real, synth, seed):
     """Check that the permutation-based null statistics can be estimated
     correctly."""
 
@@ -147,7 +150,7 @@ def test_pmse_cart_statistics(real, synth, seed):
     combined, indicator = propensity._combine_encode_and_pop(real, synth)
     synth_prop = indicator.mean()
 
-    loc, scale = propensity._pmse_cart_statistics(
+    loc, scale = propensity._pmse_cart_stats_perm(
         combined, indicator, num_perms=10, random_state=seed
     )
 
@@ -160,6 +163,56 @@ def test_pmse_cart_statistics(real, synth, seed):
         assert loc <= synth_prop**2
     else:
         assert loc <= synth_prop**2 - 2 * synth_prop + 1
+
+
+@given(st.integers(0, 100), st.sampled_from(("perm", "boot")))
+@settings(
+    deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture]
+)
+def test_pmse_cart_statistics(real, synth, seed, estimator):
+    """Check that either null statistic estimation works."""
+
+    combined, indicator = propensity._combine_encode_and_pop(real, synth)
+
+    if estimator == "perm":
+        with pytest.warns(FutureWarning, match="permutation method is flawed"):
+            loc, scale = propensity._pmse_cart_statistics(
+                combined,
+                indicator,
+                num_perms=10,
+                estimator=estimator,
+                random_state=seed,
+            )
+
+    else:
+        loc, scale = propensity._pmse_cart_statistics(
+            combined,
+            indicator,
+            num_perms=10,
+            estimator=estimator,
+            random_state=seed,
+        )
+
+    assert isinstance(loc, float)
+    assert isinstance(scale, float)
+
+    assert scale > 0
+    assert loc <= 0.25
+
+
+@given(st.text(string.ascii_lowercase))
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+def test_pmse_cart_statistics_error(real, synth, estimator):
+    """Check that an error gets raised for an invalid estimator name."""
+
+    combined, indicator = propensity._combine_encode_and_pop(real, synth)
+
+    with pytest.raises(
+        ValueError, match="^Estimation method must be `perm` or `boot`.$"
+    ):
+        _ = propensity._pmse_cart_statistics(
+            combined, indicator, num_perms=None, estimator=estimator
+        )
 
 
 @given(st.sampled_from(("logr", "cart")), st.integers(0, 100))

--- a/tests/test_metrics_propensity.py
+++ b/tests/test_metrics_propensity.py
@@ -119,6 +119,21 @@ def test_pmse_logr_statistics(real, synth, seed):
 
 
 @given(st.integers(0, 100))
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+def test_pmse_cart_stats_boot(real, seed):
+    """Check that the bootstrap-based null statistics can be estimated
+    correctly."""
+
+    loc, scale = propensity._pmse_cart_stats_boot(real, num_perms=10, random_state=seed)
+
+    assert isinstance(loc, float)
+    assert isinstance(scale, float)
+
+    assert scale > 0
+    assert loc <= 0.25
+
+
+@given(st.integers(0, 100))
 @settings(
     deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture]
 )

--- a/tests/test_metrics_propensity.py
+++ b/tests/test_metrics_propensity.py
@@ -124,7 +124,7 @@ def test_pmse_cart_stats_boot(real, synth, seed):
     """Check that the bootstrap-based null statistics can be estimated
     correctly."""
 
-    synth = _reduce_synthetic(synth)
+    synth = _reduce_synthetic(synth, seed)
     combined, indicator = propensity._combine_encode_and_pop(real, synth)
 
     loc, scale = propensity._pmse_cart_stats_boot(

--- a/tests/test_metrics_propensity.py
+++ b/tests/test_metrics_propensity.py
@@ -124,7 +124,9 @@ def test_pmse_cart_stats_boot(real, seed):
     """Check that the bootstrap-based null statistics can be estimated
     correctly."""
 
-    loc, scale = propensity._pmse_cart_stats_boot(real, num_perms=10, random_state=seed)
+    loc, scale = propensity._pmse_cart_stats_boot(
+        real, num_perms=10, random_state=seed
+    )
 
     assert isinstance(loc, float)
     assert isinstance(scale, float)


### PR DESCRIPTION
Using permutations of the synthetic data to estimate the location and scale of pMSE under the null condition for CART models ignores the fact that the performance of the model depends on the data. Our estimate for the expected pMSE should only depend on the model. This issue is explained in detail in [Bowen and Snoke (2018), Section 4.2](https://journalprivacyconfidentiality.org/index.php/jpc/article/view/748/707).

One key outcome of this problem is that it turns the privacy-utility balancing act on its head:

> As epsilon decreases, the noise in the synthetic data models increases significantly such that the estimated null becomes quite large (because each synthetic data set is very far from each other). This increase cannot be matched by an increase in the observed pMSE, because that value is bounded above. In these situations, when using the pMSE-ratio, we observe that the algorithm suggests “better” utility using lower epsilon than using higher epsilon, because the null increases with lower epsilon, thus lowering the ratio.

The authors point out that this is also troubling when comparing multiple synthetic datasets since they would each produce a unique estimate for the null pMSE. Despite being small for larger values of epsilon, the differences violate the theoretical basis of the pMSE metrics.

They describe their solution as follows:

> In this paper, we solve this problem by instead estimating the null by only using the original data. Instead of calculating the pairwise comparisons or permuting the original data with the synthetic, we bootstrap two times the number of rows from the original data,and we assign 0 labels to half and 1 labels to the other half. We then calculate the pMSE, repeat this process 100 times, and take the average value as our null pMSE. This approach ensures the null value arises from the original data, which we know came from the observed generative distribution, and the estimated null does not differ for different synthetic sets, which it should not.

This PR implements this solution as an alternative null estimation method. To ensure back-compatibility, we will keep the permutation-based method as the default. However, we should stop this in the future since the current method is flawed - perhaps we should add a `DeprecationWarning`. Or can we go ahead with the change if this constitutes a bug fix @MichaelaLawrenceONS?

[R code is available](https://github.com/ClaireMcKayBowen/Code-for-NIST-PSCR-Differential-Privacy-Synthetic-Data-Challenge/blob/master/rcode/pmse_CART_utility.R) as a supplement to the paper and will be cited in the source code.