### PR TITLE
Add SPECKS metric

### DIFF
--- a/src/synthgauge/metrics/propensity.py
+++ b/src/synthgauge/metrics/propensity.py
@@ -484,9 +484,10 @@ def specks(real, synth, classifier, **kwargs):
     The SPECKS metric was originally presented in
     https://arxiv.org/pdf/1803.06763.pdf and works as follows:
 
-        1. Stack the real and synthetic data, labelling them as such.
+        1. Stack the real and synthetic data, and create a variable
+           indicating whether each record is real (0) or synthetic (1).
         2. Calculate the propensity score for each record using a binary
-           classifier.
+           classifier on the indicator variable.
         3. Compute the Kolmogorov-Smirnov distance between the empirical
            CDFs for the real and synthetic propensity scores.
 

--- a/src/synthgauge/metrics/propensity.py
+++ b/src/synthgauge/metrics/propensity.py
@@ -484,7 +484,7 @@ def specks(real, synth, classifier, **kwargs):
     The SPECKS metric was originally presented in
     https://arxiv.org/pdf/1803.06763.pdf and works as follows:
 
-        1. Combine the real and synthetic data, labelling them as such.
+        1. Stack the real and synthetic data, labelling them as such.
         2. Calculate the propensity score for each record using a binary
            classifier.
         3. Compute the Kolmogorov-Smirnov distance between the empirical

--- a/tests/test_metrics_propensity.py
+++ b/tests/test_metrics_propensity.py
@@ -7,6 +7,9 @@ import pandas as pd
 import pytest
 from hypothesis import HealthCheck, assume, given, settings
 from hypothesis import strategies as st
+from sklearn.linear_model import LogisticRegression
+from sklearn.neighbors import KNeighborsClassifier
+from sklearn.tree import DecisionTreeClassifier
 
 from synthgauge.metrics import propensity
 
@@ -212,3 +215,20 @@ def test_propensity_metrics_error(real, synth, method):
     match = f"Propensity method must be 'cart' or 'logr' not {method}."
     with pytest.raises(ValueError, match=match):
         _ = propensity.propensity_metrics(real, synth, method)
+
+
+@given(
+    st.sampled_from(
+        (LogisticRegression, DecisionTreeClassifier, KNeighborsClassifier)
+    )
+)
+@settings(
+    deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture]
+)
+def test_specks(real, synth, classifier):
+    """Check that the SPECKS method works with different classifiers."""
+
+    score = propensity.specks(real, synth, classifier)
+
+    assert isinstance(score, float)
+    assert score >= 0 and score <= 1


### PR DESCRIPTION
Synthetic data generation; Propensity score matching; Empirical Comparison via the Kolmogorov-Smirnov distance.

This metric does what it says on the tin - providing us with another propensity-based approach to measuring generic, multivariate utility. The key benefit of this metric over the other pMSE metrics is that it does not rely on having a large dataset to be reasonably reliable.

Details in [Bowen et al (2018), Section 2.4](https://arxiv.org/abs/1803.06763). The paper has now been published in Metron under
[DOI 10.1007/s40300-021-00201-0](https://doi.org/10.1007/s40300-021-00201-0).