### PR TITLE
Prepare to archive repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@
 SynthGauge is a Python library providing a framework in which to evaluate
 synthetically generated data.
 
+> [!WARNING]
+> The `synthgauge` package is no longer actively developed by the Data Science
+> Campus, and its GitHub repository has been archived. You can still install
+> `synthgauge` from GitHub and PyPI.
+> 
+> We also recommend the package [`sdmetrics`](https://docs.sdv.dev/sdmetrics/)
+> from the [Synthetic Data Vault](https://sdv.dev/) for all of your synthetic
+> data evaluation needs.
+
 The library provides a range of metrics and visualisations for assessing and
 comparing distributions of features between real and synthetic data. At its
 core is the `Evaluator` class, which provides a consistent interface for

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,41 +21,37 @@ classifiers =
 package_dir =
     = src
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
-    kmodes>=0.11.1
-    matplotlib>=3.3.2
-    numpy>=1.19.2
-    scikit-learn>=0.24.0
-    pandas>=1.1.3
-    scipy>=1.5.2
-    seaborn>=0.11.0,<0.12.0
+    kmodes==0.12.2
+    matplotlib==3.5.3
+    numpy==1.21.6
+    scikit-learn==1.0.2
+    pandas==1.3.5
+    scipy==1.7.3
+    seaborn==0.11.2
 
 [options.packages.find]
 where = src
 
 [options.extras_require]
 docs =
-    ipython==7.17.0; python_version>'3.6'
-    ipython==7.16.3; python_version<'3.7'
-    nbsphinx==0.8.9; python_version>'3.6'
-    nbsphinx==0.8.8; python_version<'3.7'
+    ipython==7.17.0
+    nbsphinx==0.8.9
     nbsphinx_link==1.3.0
     sphinx==4.3.2
     sphinx-autoapi==1.8.4
     sphinx-rtd-theme==1.0.0
 test =
-    hypothesis>=6.47.2; python_version>'3.6'
-    hypothesis==6.31.6; python_version<'3.7'
-    pytest>=6.2.5
+    hypothesis==6.54.6
+    pytest==7.1.3
     pytest-cov==3.0.0
-    pytest-randomly==3.12.0; python_version>'3.6'
-    pytest-randomly==3.10.3; python_version<'3.7'
+    pytest-randomly==3.12.0
 dev =
-    black>=22.3.0
-    flake8>=4.0.1
-    interrogate>=1.5.0
-    isort>=5.10.1
-    pre-commit>=2.17.0
+    black==22.8.0
+    flake8==5.0.4
+    interrogate==1.5.0
+    isort==5.10.1
+    pre-commit==2.20.0
     synthgauge[docs]
     synthgauge[test]


### PR DESCRIPTION
This PR adds a banner at the top of the README to indicate that we will not be developing the package any longer, and that `sdmetrics` is our preferred alternative (agreed with @owendanielONS and @MichaelaLawrenceONS many moons ago now!)